### PR TITLE
fix: Add localStorage mock

### DIFF
--- a/src/withDOM.js
+++ b/src/withDOM.js
@@ -11,11 +11,39 @@ function copyProps(src, target) {
   });
 }
 
+// Simple localStorage mock.
+// The standard storage resulted in an error:
+// "TypeError: 'getItem' called on an object that is not a valid instance of Storage."
+const localStorageMock = (function() {
+  let store = {}
+
+  return {
+    getItem: function(key) {
+      return store[key] || null
+    },
+    setItem: function(key, value) {
+      store[key] = value
+    },
+    removeItem: function(key) {
+      delete store[key]
+    },
+    clear: function() {
+      store = {}
+    }
+  }
+})()
+
 exports.withDOM = function (test) {
   return async (...args) => {
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: "https://example.test"
+  });
 
     const { window } = dom;
+
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock
+    })
 
     global.window = window;
     global.document = window.document;
@@ -29,6 +57,8 @@ exports.withDOM = function (test) {
     global.cancelAnimationFrame = function (id) {
       clearTimeout(id);
     };
+
+    
 
     copyProps(window, global);
 

--- a/test/ZoraJsdom_test.res
+++ b/test/ZoraJsdom_test.res
@@ -47,3 +47,30 @@ Zora.zoraBlock("Reset document between tests", t => {
     done()
   })
 })
+
+type localStorageType = {
+  getItem: 'a. string => 'a,
+  setItem: 'a. (string, 'a) => unit,
+  removeItem: string => unit,
+  clear: unit => unit,
+}
+
+type rType = {a: string}
+
+ZoraJsdom.zoraWithDOM("localStorage works", t => {
+  let ls: localStorageType = window["localStorage"]
+  // ok works here because type of window is generic
+  ls.setItem("mykey1", "myvalue")
+  t->equal(ls.getItem("mykey1"), "myvalue", "should have item with value 'mykey'")
+  ls.setItem("mykey2", 1)
+  t->equal(ls.getItem("mykey2"), 1, "should have item with value 1")
+  ls.setItem("mykey3", {a: "val"})
+  t->equal(ls.getItem("mykey3"), {a: "val"}, "should have item with value {a: 'val'}")
+  ls.removeItem("mykey1")
+  t->equal(ls.getItem("mykey1"), Js.null, "item should be deleted")
+  ls.clear()
+  t->equal(ls.getItem("mykey1"), Js.null, "item should be deleted")
+  t->equal(ls.getItem("mykey2"), Js.null, "item should be deleted")
+  t->equal(ls.getItem("mykey3"), Js.null, "item should be deleted")
+  done()
+})


### PR DESCRIPTION
jsdom localStorage didn't work in tests and resulted in an error:
TypeError: 'getItem' called on an object that is not a valid instance
of Storage.

The localStorage mock circumvents the restrictions of "normal" storage.